### PR TITLE
Do not include usage params that are blank

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -51,9 +51,15 @@ func (twilio *Twilio) GetUsage(category, startDate, endDate string, includeSubac
 
 func (twilio *Twilio) GetUsageWithContext(ctx context.Context, category, startDate, endDate string, includeSubaccounts bool) (*UsageResponse, *Exception, error) {
 	formValues := url.Values{}
-	formValues.Set("Category", category)
-	formValues.Set("StartDate", startDate)
-	formValues.Set("EndDate", endDate)
+	if category != "" {
+		formValues.Set("Category", category)
+	}
+	if startDate != "" {
+		formValues.Set("StartDate", startDate)
+	}
+	if endDate != "" {
+		formValues.Set("EndDate", endDate)
+	}
 	formValues.Set("IncludeSubaccounts", strconv.FormatBool(includeSubaccounts))
 
 	var usageResponse *UsageResponse


### PR DESCRIPTION
If you leave things blank (particularly Category) then Twilio responds with `Code 20001:  is not a valid choice` presumably because blank isn't a valid category. Of course, if you don't include Category at all it happily returns all of the categories, grrr.